### PR TITLE
Static/bugfix/transactions db adapter bugs

### DIFF
--- a/app/src/main/java/org/gnucash/android/db/adapter/TransactionsDbAdapter.java
+++ b/app/src/main/java/org/gnucash/android/db/adapter/TransactionsDbAdapter.java
@@ -513,8 +513,6 @@ public class TransactionsDbAdapter extends DatabaseAdapter<Transaction> {
      * @return Number of splits belonging to the transaction
      */
     public long getSplitCount(@NonNull String transactionUID){
-        if (transactionUID == null)
-            return 0;
         String sql = "SELECT COUNT(*) FROM " + SplitEntry.TABLE_NAME
                 + " WHERE " + SplitEntry.COLUMN_TRANSACTION_UID + "= '" + transactionUID + "'";
         SQLiteStatement statement = mDb.compileStatement(sql);

--- a/app/src/main/java/org/gnucash/android/db/adapter/TransactionsDbAdapter.java
+++ b/app/src/main/java/org/gnucash/android/db/adapter/TransactionsDbAdapter.java
@@ -119,7 +119,8 @@ public class TransactionsDbAdapter extends DatabaseAdapter<Transaction> {
                 } else {
                     mSplitsDbAdapter.addRecord(split, updateMethod);
                 }
-                splitUIDs.add(split.getUID());
+                if (split != null)
+                    splitUIDs.add(split.getUID());
             }
             Log.d(LOG_TAG, transaction.getSplits().size() + " splits added");
 


### PR DESCRIPTION
Removed an unnecessary null check where the parameter can't be null.
Added a null check where NullPointerException can happen.
 
Closes #13 