### PR TITLE
Fixing the static dateformat problem so it would work in multithread …

### DIFF
--- a/app/src/main/java/org/gnucash/android/export/Exporter.java
+++ b/app/src/main/java/org/gnucash/android/export/Exporter.java
@@ -85,7 +85,7 @@ public abstract class Exporter {
      */
     private final File mCacheDir;
 
-    private static final SimpleDateFormat EXPORT_FILENAME_DATE_FORMAT = new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US);
+    //private final SimpleDateFormat EXPORT_FILENAME_DATE_FORMAT = new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US);
 
     /**
      * Adapter for retrieving accounts to export
@@ -159,6 +159,7 @@ public abstract class Exporter {
      * @return String containing the file name
      */
     public static String buildExportFilename(ExportFormat format, String bookName) {
+        final SimpleDateFormat EXPORT_FILENAME_DATE_FORMAT = new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US);
         return EXPORT_FILENAME_DATE_FORMAT.format(new Date(System.currentTimeMillis()))
                 + "_gnucash_export_" + sanitizeFilename(bookName) +
                 (format == ExportFormat.CSVA ? "_accounts" : "") +
@@ -172,6 +173,8 @@ public abstract class Exporter {
      * @return Date in milliseconds
      */
     public static long getExportTime(String filename){
+        final SimpleDateFormat EXPORT_FILENAME_DATE_FORMAT = new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US);
+
         String[] tokens = filename.split("_");
         long timeMillis = 0;
         if (tokens.length < 2){


### PR DESCRIPTION
Since the exporter is used in the ExportAsyncTask.java it can be used in multi-threaded manner. So the static dateformat is not the best beacuse it is not thread safe.
The solution would be to make it an instance variable but there are static methods that use it. So i moved the variable to the methods and deleted from the class. (because only 2 methods uses it)

Closes #21 