### PR TITLE
Using try-with-resources in GncXmlExporter.java

### DIFF
--- a/app/src/main/java/org/gnucash/android/export/xml/GncXmlExporter.java
+++ b/app/src/main/java/org/gnucash/android/export/xml/GncXmlExporter.java
@@ -776,25 +776,15 @@ public class GncXmlExporter extends Exporter{
 
     @Override
     public List<String> generateExport() throws ExporterException {
-        OutputStreamWriter writer = null;
         String outputFile = getExportCacheFilePath();
-        try {
-            FileOutputStream fileOutputStream = new FileOutputStream(outputFile);
-            BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(fileOutputStream);
-            writer = new OutputStreamWriter(bufferedOutputStream);
+        try (FileOutputStream fileOutputStream = new FileOutputStream(outputFile);
+             BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(fileOutputStream);
+             OutputStreamWriter writer = new OutputStreamWriter(bufferedOutputStream)){
 
             generateExport(writer);
         } catch (IOException ex){
             Crashlytics.log("Error exporting XML");
             Crashlytics.logException(ex);
-        } finally {
-            if (writer != null) {
-                try {
-                    writer.close();
-                } catch (IOException e) {
-                    throw new ExporterException(mExportParams, e);
-                }
-            }
         }
 
         List<String> exportedFiles = new ArrayList<>();


### PR DESCRIPTION
With try-with-resources, we can assure that all used resources will be closed, in addition the __throw__ in the finally block won't be needed (a throw in a finally block is generally a bad practice, because the original exception, which could have been thrown before, is shadowed by this new exception)

Fixes issue #22 