### PR TITLE
Re-interrupt after InterruptedException catched

### DIFF
--- a/app/src/main/java/org/gnucash/android/service/ScheduledActionService.java
+++ b/app/src/main/java/org/gnucash/android/service/ScheduledActionService.java
@@ -178,6 +178,8 @@ public class ScheduledActionService extends JobIntentService {
         } catch (InterruptedException | ExecutionException e) {
             Crashlytics.logException(e);
             Log.e(LOG_TAG, e.getMessage());
+
+            Thread.currentThread().interrupt();
         }
         if (!result) {
             Log.i(LOG_TAG, "Backup/export did not occur. There might have been no"

--- a/app/src/main/java/org/gnucash/android/ui/settings/AccountPreferencesFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/settings/AccountPreferencesFragment.java
@@ -215,6 +215,8 @@ public class AccountPreferencesFragment extends PreferenceFragmentCompat impleme
                         Crashlytics.logException(e);
                         Toast.makeText(getActivity(), "An error occurred during the Accounts CSV export",
                                 Toast.LENGTH_LONG).show();
+
+                        Thread.currentThread().interrupt();
                     }
                 }
         }


### PR DESCRIPTION
After the __InterruptedException__ has been caught, the logging can be done, and lastly the thread should be re-interrupted, hereby the interrupted state of the thread won't be lost.

Fixes #25 