### PR TITLE
Change BigDecimal ctor to BigDecimal.valueOf

### DIFF
--- a/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
@@ -314,7 +314,7 @@ public class SplitEditorFragment extends Fragment {
             }
 
             if (expression != null && expression.validate().isValid()) {
-                return new BigDecimal(expression.evaluate());
+                return BigDecimal.valueOf(expression.evaluate());
             } else {
                 Log.v(SplitEditorFragment.this.getClass().getSimpleName(),
                         "Incomplete expression for updating imbalance: " + expression);

--- a/app/src/main/java/org/gnucash/android/ui/util/widget/CalculatorEditText.java
+++ b/app/src/main/java/org/gnucash/android/ui/util/widget/CalculatorEditText.java
@@ -264,7 +264,7 @@ public class CalculatorEditText extends AppCompatEditText {
         }
 
         if (expression != null && expression.validate().isValid()) {
-            BigDecimal result = new BigDecimal(expression.evaluate());
+            BigDecimal result = BigDecimal.valueOf(expression.evaluate());
             setValue(result);
         } else {
             setError(getContext().getString(R.string.label_error_invalid_expression));


### PR DESCRIPTION
To avoid imprecisions, __BigDecimal.valueOf__ should be used insted of the constructor. These alternations have been made in _SplitEditorFragment.java_ and _CalculatorEditText.java_. Under the hood, valueOf uses Strings.

Fixes #27 